### PR TITLE
결제 파트 리팩토링 및 수정사항

### DIFF
--- a/src/app/(root)/check-payment/_components/CheckPaymentContent.tsx
+++ b/src/app/(root)/check-payment/_components/CheckPaymentContent.tsx
@@ -40,6 +40,7 @@ const CheckPaymentContent = () => {
               method,
               customer,
               products
+              //TODO webhooks
             } = payHistory;
             const newPaidAt = dayjs(paidAt)
               .locale('ko')

--- a/src/app/(root)/local-food/page.tsx
+++ b/src/app/(root)/local-food/page.tsx
@@ -1,6 +1,5 @@
-import WebHeader from '@/components/common/header/WebHeader';
-import LocalFoodView from './_components/LocalFoodView';
 import { Metadata } from 'next';
+import LocalFoodView from './_components/LocalFoodView';
 
 export const metadata: Metadata = {
   title: '특산물',

--- a/src/app/(root)/payment/_components/PayHistoryItem.tsx
+++ b/src/app/(root)/payment/_components/PayHistoryItem.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { toast } from '@/components/ui/use-toast';
+import { usePaymentCancellation } from '@/hooks/payment/canclePayWithDbUpdate';
+import { imageSrc } from '@/hooks/payment/getProductImage';
+import useDeletePayHistory from '@/hooks/payment/useDeletePayHistory';
+import {
+  BaseOrderInPayHistory,
+  Order,
+  OrderListInPayHistory,
+  Product
+} from '@/types/payHistory';
+import dayjs from 'dayjs';
+import { useRouter } from 'next/navigation';
+import { CgClose } from 'react-icons/cg';
+import Swal from 'sweetalert2';
+import ReviewProductDetail from './ReviewProductDetail';
+
+interface Props {
+  orderList: OrderListInPayHistory;
+  date: string;
+}
+const PayHistoryItem = ({ orderList, date }: Props) => {
+  const route = useRouter();
+  const deletePayHistory = useDeletePayHistory();
+
+  const deletePayment = async (order: Order) => {
+    const { payment_id } = order;
+    Swal.fire({
+      title: '주문 내역을 삭제하시겠어요?',
+      html: `
+      <div id="swal2-html-container" class="swal2-html-container" style=" padding:0 !important; margin:-1rem; font-size:16px;">내역 삭제시에는 복구 및 주문 취소가 불가해요.</div>
+    `,
+      showCancelButton: true,
+      cancelButtonColor: '#9C6D2E',
+      confirmButtonColor: '#f2f2f2',
+      cancelButtonText: '취소하기',
+      confirmButtonText: '삭제하기',
+      customClass: {
+        title: 'text-xl mt-10 md:mb-[8px]',
+        popup: 'rounded-[16px]',
+        actions: 'flex gap-3 mb-6 mt-9 md:mt-[40px] md:mb-[28px]',
+        confirmButton:
+          'text-status-negative py-3 px-4 rounded-[12px] w-[138px] m-0',
+        cancelButton: 'text-white py-3 px-4 rounded-[12px] w-[138px] m-0'
+      }
+    }).then((result) => {
+      if (result.isConfirmed) {
+        deletePayHistory.mutate(payment_id);
+      }
+    });
+  };
+
+  //취소 및 db 업데이트
+
+  const cancelPaymentMutation = usePaymentCancellation();
+
+  const cancelPayment = async (order: BaseOrderInPayHistory) => {
+    Swal.fire({
+      title: '구매 상품을 환불하시겠어요?',
+      html: `
+        <div id="swal2-html-container" class="swal2-html-container" style=" padding:0 !important; margin:-1rem; font-size:16px;">환불 후에는 리뷰 작성 및 환불 취소가 불가해요.</div>
+      `,
+      showCancelButton: true,
+      cancelButtonColor: '#9C6D2E',
+      confirmButtonColor: '#f2f2f2',
+      cancelButtonText: '환불 취소',
+      confirmButtonText: '환불하기',
+      customClass: {
+        title: 'text-xl mt-10 md:mb-[8px]',
+        popup: 'rounded-[16px]',
+        actions: 'flex gap-3 mb-6 mt-9 md:mt-[40px] md:mb-[28px]',
+        confirmButton:
+          'text-status-negative py-3 px-4 rounded-[12px] w-[138px] m-0',
+        cancelButton: 'text-white py-3 px-4 rounded-[12px] w-[138px] m-0'
+      }
+    }).then(async (result) => {
+      if (result.isConfirmed) {
+        const { status, payment_id, ...rest } = order;
+        const newHistory = {
+          status: 'CANCELLED',
+          payment_id,
+          ...rest
+        };
+        try {
+          await cancelPaymentMutation.mutateAsync({ payment_id, newHistory });
+        } catch (error) {
+          console.error('주문 취소 중 오류 발생:', error);
+        }
+      }
+      return;
+    });
+  };
+
+  return (
+    <div className="px-[16px] md:p-0">
+      {orderList[date].map((order: any) => (
+        <div key={order.id}>
+          <div className="border rounded-[12px] p-[16px] mt-[8px] mb-[16px] bg-white">
+            <div className="flex justify-between items-center">
+              <div className="flex gap-[4px] items-center md:text-[18px]">
+                <p className="font-medium">
+                  {order.status === 'CANCELLED' ? '주문취소완료' : '결제 완료'}
+                </p>
+                <p className="text-[#AFAFAF]">
+                  {order.status === 'CANCELLED' ? null : '·'}
+                </p>
+                <div className="flex">
+                  {order.status === 'PAID' && (
+                    <p className="text-[#9C6D2E] font-normal">
+                      {dayjs(order.payment_date)
+                        .locale('ko')
+                        .format('MM/DD (ddd)')}{' '}
+                      도착 예정
+                    </p>
+                  )}
+                </div>
+              </div>
+              <CgClose
+                onClick={() => deletePayment(order)}
+                className="text-[#959595] w-7 h-7 p-1 cursor-pointer"
+              />
+            </div>
+
+            {order.products.map((product: Product, index: number) => (
+              <div
+                className="cursor-pointer"
+                key={product.id}
+                onClick={() => route.push(`local-food/${product.id}`)}
+              >
+                <div
+                  className={`flex gap-[12px] mt-[12px] ${
+                    index !== order.products.length - 1
+                      ? 'border-b-2 pb-[12px]'
+                      : ''
+                  }`}
+                >
+                  <img
+                    src={imageSrc(product.name)}
+                    className="w-[64px] h-[64px] object-cover rounded-[8px] xs:w-[100px] xs:h-[100px]"
+                    alt={`${product.name}`}
+                  />
+
+                  <div className="flex flex-col justify-center gap-[8px]">
+                    <p className="font-medium text-[16px] md:text-[20px]">
+                      {product.name}
+                    </p>
+                    <div className="flex text-[#79746D] gap-[4px] md:gap-2">
+                      <p>{product.amount.toLocaleString()}원</p>
+                      <p>·</p>
+                      <p>{product.quantity}개</p>
+                    </div>
+                  </div>
+                  {index !== order.products.length - 1 && <hr />}
+                </div>
+              </div>
+            ))}
+
+            <div
+              className={`flex justify-center gap-[8px] text-[14px] font-semibold pt-[12px] ${
+                order.status !== 'CANCELLED' ? 'flex' : 'hidden'
+              } self-stretch`}
+            >
+              <button
+                className="flex flex-1 justify-center items-center py-[10px] px-[16px] border-[1px] border-[#AFAFAF] text-[#79746D] h-[40px] rounded-[10px]"
+                onClick={() => cancelPayment(order)}
+              >
+                주문취소
+              </button>
+              <button
+                className="flex flex-1 justify-center items-center py-[10px] px-[16px] border-[1px] border-[#9C6D2E] text-[#9C6D2E] h-[40px] rounded-[10px]"
+                onClick={() => {
+                  toast({
+                    variant: 'destructive',
+                    description: '서비스 준비 중이에요.'
+                  });
+                }}
+              >
+                배송조회
+              </button>
+            </div>
+          </div>
+          <div className="w-full mb-4 bg-slate-200">
+            <ReviewProductDetail order={order} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PayHistoryItem;

--- a/src/app/(root)/payment/_components/PayHistoryItem.tsx
+++ b/src/app/(root)/payment/_components/PayHistoryItem.tsx
@@ -52,7 +52,6 @@ const PayHistoryItem = ({ orderList, date }: Props) => {
   };
 
   //취소 및 db 업데이트
-
   const cancelPaymentMutation = usePaymentCancellation();
 
   const cancelPayment = async (order: BaseOrderInPayHistory) => {

--- a/src/app/(root)/payment/_components/PayHistoryList.tsx
+++ b/src/app/(root)/payment/_components/PayHistoryList.tsx
@@ -9,6 +9,8 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
 import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
 import NoPayHistory from './NoPayHistory';
 import PayHistoryItem from './PayHistoryItem';
 import TopIconInDesktop from './TopIconInDesktop';
@@ -23,9 +25,25 @@ const PayHistoryList = () => {
 
   const userId = users?.id;
 
-  const { payHistoryList } = useGetPaymentHistoryWithSupabase(userId);
+  const {
+    payHistoryList,
+    isPending,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
+  } = useGetPaymentHistoryWithSupabase(userId);
 
-  if (!payHistoryList) {
+  const { ref, inView } = useInView({
+    threshold: 0
+  });
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, fetchNextPage]);
+
+  if (!payHistoryList || isPending) {
     return <Loading />;
   }
 
@@ -71,6 +89,7 @@ const PayHistoryList = () => {
               <hr className="border-2 border-[#F2F2F2]" />
             </div>
           ))}
+          {isFetchingNextPage ? <Loading /> : hasNextPage && <div ref={ref} />}
         </div>
       )}
     </>

--- a/src/app/(root)/payment/_components/PayHistoryList.tsx
+++ b/src/app/(root)/payment/_components/PayHistoryList.tsx
@@ -1,31 +1,19 @@
 'use client';
 
 import Loading from '@/components/common/Loading';
-import { toast } from '@/components/ui/use-toast';
-import { usePaymentCancellation } from '@/hooks/payment/canclePayWithDbUpdate';
-import { imageSrc } from '@/hooks/payment/getProductImage';
-import useDeletePayHistory from '@/hooks/payment/useDeletePayHistory';
 import { useGetPaymentHistoryWithSupabase } from '@/hooks/payment/useGetPaymentHistory';
 import api from '@/service/service';
-import {
-  BaseOrderInPayHistory,
-  Order,
-  OrderListInPayHistory,
-  Product
-} from '@/types/payHistory';
+import { OrderListInPayHistory } from '@/types/payHistory';
 import { Tables } from '@/types/supabase';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
-import { usePathname, useRouter } from 'next/navigation';
-import { BsChevronRight } from 'react-icons/bs';
-import { CgClose } from 'react-icons/cg';
-import Swal from 'sweetalert2';
+import { usePathname } from 'next/navigation';
 import NoPayHistory from './NoPayHistory';
-import ReviewProductDetail from './ReviewProductDetail';
+import PayHistoryItem from './PayHistoryItem';
+import TopIconInDesktop from './TopIconInDesktop';
 
 const PayHistoryList = () => {
-  const route = useRouter();
   const pathName = usePathname();
 
   const { data: users } = useQuery<Tables<'users'>, Error, Tables<'users'>>({
@@ -36,8 +24,6 @@ const PayHistoryList = () => {
   const userId = users?.id;
 
   const { payHistoryList } = useGetPaymentHistoryWithSupabase(userId);
-  const cancelPaymentMutation = usePaymentCancellation();
-  const deletePayHistory = useDeletePayHistory();
 
   if (!payHistoryList) {
     return <Loading />;
@@ -58,71 +44,6 @@ const PayHistoryList = () => {
     (a, b) => Date.parse(b) - Date.parse(a)
   );
 
-  //취소 및 db 업데이트
-  const cancelPayment = async (order: BaseOrderInPayHistory) => {
-    Swal.fire({
-      title: '구매 상품을 환불하시겠어요?',
-      html: `
-      <div id="swal2-html-container" class="swal2-html-container" style=" padding:0 !important; margin:-1rem; font-size:16px;">환불 후에는 리뷰 작성 및 환불 취소가 불가해요.</div>
-    `,
-      showCancelButton: true,
-      cancelButtonColor: '#9C6D2E',
-      confirmButtonColor: '#f2f2f2',
-      cancelButtonText: '환불 취소',
-      confirmButtonText: '환불하기',
-      customClass: {
-        title: 'text-xl mt-10 md:mb-[8px]',
-        popup: 'rounded-[16px]',
-        actions: 'flex gap-3 mb-6 mt-9 md:mt-[40px] md:mb-[28px]',
-        confirmButton:
-          'text-status-negative py-3 px-4 rounded-[12px] w-[138px] m-0',
-        cancelButton: 'text-white py-3 px-4 rounded-[12px] w-[138px] m-0'
-      }
-    }).then(async (result) => {
-      if (result.isConfirmed) {
-        const { status, payment_id, ...rest } = order;
-        const newHistory = {
-          status: 'CANCELLED',
-          payment_id,
-          ...rest
-        };
-        try {
-          await cancelPaymentMutation.mutateAsync({ payment_id, newHistory });
-        } catch (error) {
-          console.error('주문 취소 중 오류 발생:', error);
-        }
-      }
-      return;
-    });
-  };
-
-  const deletePayment = async (order: Order) => {
-    const { payment_id } = order;
-    Swal.fire({
-      title: '주문 내역을 삭제하시겠어요?',
-      html: `
-      <div id="swal2-html-container" class="swal2-html-container" style=" padding:0 !important; margin:-1rem; font-size:16px;">내역 삭제시에는 복구 및 주문 취소가 불가해요.</div>
-    `,
-      showCancelButton: true,
-      cancelButtonColor: '#9C6D2E',
-      confirmButtonColor: '#f2f2f2',
-      cancelButtonText: '취소하기',
-      confirmButtonText: '삭제하기',
-      customClass: {
-        title: 'text-xl mt-10 md:mb-[8px]',
-        popup: 'rounded-[16px]',
-        actions: 'flex gap-3 mb-6 mt-9 md:mt-[40px] md:mb-[28px]',
-        confirmButton:
-          'text-status-negative py-3 px-4 rounded-[12px] w-[138px] m-0',
-        cancelButton: 'text-white py-3 px-4 rounded-[12px] w-[138px] m-0'
-      }
-    }).then((result) => {
-      if (result.isConfirmed) {
-        deletePayHistory.mutate(payment_id);
-      }
-    });
-  };
-
   const datesToRender =
     pathName === '/my-page' ? [sortedDates[0]] : sortedDates;
 
@@ -136,29 +57,7 @@ const PayHistoryList = () => {
             pathName === '/payment' && 'pt-[16px] mt-[3.25rem]'
           }`}
         >
-          <div
-            className={`hidden py-10 border-b-8 border-[#F2F2F2] md:flex md:justify-between ${
-              pathName === '/my-page' && 'border-none'
-            }`}
-          >
-            <img
-              src="/image/pay_history_tiger.png"
-              alt="복숭아 든 귀여운 호랑이"
-            />
-            <div
-              className={`flex items-center text-[14px] gap-1 ${
-                pathName === '/payment' && 'hidden'
-              }`}
-            >
-              <span
-                className="underline cursor-pointer"
-                onClick={() => route.push('payment')}
-              >
-                더보기
-              </span>
-              <BsChevronRight className=" w-4 h-4 text-[#545454] cursor-pointer" />
-            </div>
-          </div>
+          <TopIconInDesktop />
           {datesToRender.map((date) => (
             <div
               key={date}
@@ -168,101 +67,7 @@ const PayHistoryList = () => {
                 <p className="font-medium">{date}</p>
                 <p className="font-medium">주문</p>
               </div>
-              <div className="px-[16px] md:p-0">
-                {orderList[date].map((order: any) => (
-                  <div key={order.id}>
-                    <div className="border rounded-[12px] p-[16px] mt-[8px] mb-[16px] bg-white">
-                      <div className="flex justify-between items-center">
-                        <div className="flex gap-[4px] items-center md:text-[18px]">
-                          <p className="font-medium">
-                            {order.status === 'CANCELLED'
-                              ? '주문취소완료'
-                              : '결제 완료'}
-                          </p>
-                          <p className="text-[#AFAFAF]">
-                            {order.status === 'CANCELLED' ? null : '·'}
-                          </p>
-                          <div className="flex">
-                            {order.status === 'PAID' && (
-                              <p className="text-[#9C6D2E] font-normal">
-                                {dayjs(order.payment_date)
-                                  .locale('ko')
-                                  .format('MM/DD (ddd)')}{' '}
-                                도착 예정
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                        <CgClose
-                          onClick={() => deletePayment(order)}
-                          className="text-[#959595] w-7 h-7 p-1 cursor-pointer"
-                        />
-                      </div>
-
-                      {order.products.map((product: Product, index: number) => (
-                        <div
-                          className="cursor-pointer"
-                          key={product.id}
-                          onClick={() => route.push(`local-food/${product.id}`)}
-                        >
-                          <div
-                            className={`flex gap-[12px] mt-[12px] ${
-                              index !== order.products.length - 1
-                                ? 'border-b-2 pb-[12px]'
-                                : ''
-                            }`}
-                          >
-                            <img
-                              src={imageSrc(product.name)}
-                              className="w-[64px] h-[64px] object-cover rounded-[8px] xs:w-[100px] xs:h-[100px]"
-                              alt={`${product.name}`}
-                            />
-
-                            <div className="flex flex-col justify-center gap-[8px]">
-                              <p className="font-medium text-[16px] md:text-[20px]">
-                                {product.name}
-                              </p>
-                              <div className="flex text-[#79746D] gap-[4px] md:gap-2">
-                                <p>{product.amount.toLocaleString()}원</p>
-                                <p>·</p>
-                                <p>{product.quantity}개</p>
-                              </div>
-                            </div>
-                            {index !== order.products.length - 1 && <hr />}
-                          </div>
-                        </div>
-                      ))}
-
-                      <div
-                        className={`flex justify-center gap-[8px] text-[14px] font-semibold pt-[12px] ${
-                          order.status !== 'CANCELLED' ? 'flex' : 'hidden'
-                        } self-stretch`}
-                      >
-                        <button
-                          className="flex flex-1 justify-center items-center py-[10px] px-[16px] border-[1px] border-[#AFAFAF] text-[#79746D] h-[40px] rounded-[10px]"
-                          onClick={() => cancelPayment(order)}
-                        >
-                          주문취소
-                        </button>
-                        <button
-                          className="flex flex-1 justify-center items-center py-[10px] px-[16px] border-[1px] border-[#9C6D2E] text-[#9C6D2E] h-[40px] rounded-[10px]"
-                          onClick={() => {
-                            toast({
-                              variant: 'destructive',
-                              description: '서비스 준비 중이에요.'
-                            });
-                          }}
-                        >
-                          배송조회
-                        </button>
-                      </div>
-                    </div>
-                    <div className="w-full mb-4 bg-slate-200">
-                      <ReviewProductDetail order={order} />
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <PayHistoryItem orderList={orderList} date={date} />
               <hr className="border-2 border-[#F2F2F2]" />
             </div>
           ))}

--- a/src/app/(root)/payment/_components/ReviewForm.tsx
+++ b/src/app/(root)/payment/_components/ReviewForm.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -32,7 +34,6 @@ type Props = {
   onBack: () => void;
   hasWrittenReview?: boolean;
   payment_date: string | null;
-  reviewIsOpen: boolean;
   setIsEditing: Dispatch<SetStateAction<boolean>>;
   isEditing: boolean;
 };
@@ -41,7 +42,6 @@ const ReviewForm = ({
   onBack,
   hasWrittenReview,
   payment_date,
-  reviewIsOpen,
   isEditing,
   setIsEditing
 }: Props) => {

--- a/src/app/(root)/payment/_components/ReviewProductDetail.tsx
+++ b/src/app/(root)/payment/_components/ReviewProductDetail.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   Dialog,
   DialogContent,
@@ -117,7 +119,6 @@ const ReviewProductDetail = ({ order }: Props) => {
                 onBack={() => setSelectedProduct(null)}
                 hasWrittenReview={selectedProduct.hasReview}
                 payment_date={payment_date}
-                reviewIsOpen={reviewIsOpen}
                 setIsEditing={setIsEditing}
                 isEditing={isEditing}
               />

--- a/src/app/(root)/payment/_components/TopIconInDesktop.tsx
+++ b/src/app/(root)/payment/_components/TopIconInDesktop.tsx
@@ -1,0 +1,31 @@
+import { usePathname, useRouter } from 'next/navigation';
+import { BsChevronRight } from 'react-icons/bs';
+
+const TopIconInDesktop = () => {
+  const pathName = usePathname();
+  const route = useRouter();
+  return (
+    <div
+      className={`hidden py-10 border-b-8 border-[#F2F2F2] md:flex md:justify-between ${
+        pathName === '/my-page' && 'border-none'
+      }`}
+    >
+      <img src="/image/pay_history_tiger.png" alt="복숭아 든 귀여운 호랑이" />
+      <div
+        className={`flex items-center text-[14px] gap-1 ${
+          pathName === '/payment' && 'hidden'
+        }`}
+      >
+        <span
+          className="underline cursor-pointer"
+          onClick={() => route.push('payment')}
+        >
+          더보기
+        </span>
+        <BsChevronRight className=" w-4 h-4 text-[#545454] cursor-pointer" />
+      </div>
+    </div>
+  );
+};
+
+export default TopIconInDesktop;

--- a/src/app/(root)/payment/layout.tsx
+++ b/src/app/(root)/payment/layout.tsx
@@ -1,25 +1,25 @@
-'use client';
-
-import useDeviceSize from '@/hooks/useDeviceSize';
+import { Metadata } from 'next';
+import dynamic from 'next/dynamic';
 import { PropsWithChildren } from 'react';
-import Profile from '../my-page/_components/Profile';
+
+export const metadata: Metadata = {
+  title: '향그리움-주문내역',
+  description: '구매하신 특산품 주문 내역을 확인하실 수 있는 페이지입니다.'
+};
+
+const Profile = dynamic(() => import('../my-page/_components/Profile'), {
+  ssr: true
+});
 
 function MyPageLayout({ children }: PropsWithChildren) {
-  const { isDesktop } = useDeviceSize();
   return (
-    <div
-      className={`min-h-screen max-w-[1280px] mx-auto md:px-4 ${
-        isDesktop ? 'flex' : ''
-      }`}
-    >
-      {isDesktop && (
-        <aside className="w-1/2 md:mr-6">
-          <div className="max-w-[503px] md:mt-20 md:max-h-[422px] md:p-10 md:bg-primary-70 md:rounded-xl">
-            <Profile />
-          </div>
-        </aside>
-      )}
-      <main className={`${isDesktop ? 'w-2/3' : 'w-full'}`}>{children}</main>
+    <div className="min-h-screen max-w-[1280px] mx-auto px-4 lg:flex">
+      <aside className="hidden lg:block lg:w-1/2 lg:mr-6">
+        <div className="max-w-[503px] mt-20 max-h-[422px] p-10 bg-primary-70 rounded-xl">
+          <Profile />
+        </div>
+      </aside>
+      <main className="w-full lg:w-2/3">{children}</main>
     </div>
   );
 }

--- a/src/app/(root)/payment/page.tsx
+++ b/src/app/(root)/payment/page.tsx
@@ -1,10 +1,4 @@
 import PayHistoryList from '@/app/(root)/payment/_components/PayHistoryList';
-import { Metadata } from 'next';
-
-export const metadata: Metadata = {
-  title: '향그리움-주문내역',
-  description: '구매하신 특산품 주문 내역을 확인하실 수 있는 페이지입니다.'
-};
 
 const PaymentList = () => {
   return (

--- a/src/app/(root)/payment/page.tsx
+++ b/src/app/(root)/payment/page.tsx
@@ -1,4 +1,4 @@
-import PayHistory from '@/app/(root)/payment/_components/PayHistoryList';
+import PayHistoryList from '@/app/(root)/payment/_components/PayHistoryList';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 const PaymentList = () => {
   return (
     <>
-      <PayHistory />
+      <PayHistoryList />
     </>
   );
 };

--- a/src/app/api/payment/pay-supabase/route.ts
+++ b/src/app/api/payment/pay-supabase/route.ts
@@ -14,24 +14,29 @@ export const POST = async (request: NextRequest) => {
 };
 
 export const GET = async (request: NextRequest) => {
+
   try {
     const url = new URL(request.url);
     const userId = url.searchParams.get('user_id');
+    const page =  parseInt(url.searchParams.get('page') || '1',10)
 
     if (!userId) {
       return NextResponse.json({ message: '유저 정보를 찾을 수 없습니다' }, { status: 400 });
     }
+    const PAGE_PER_ITEM: number = 3;
 
-    const response = await supabase
+    const start = (page - 1) * PAGE_PER_ITEM
+    const end = start + PAGE_PER_ITEM - 1
+
+    const {data, error} = await supabase
       .from('orderd_list')
       .select('*')
       .order('created_at', { ascending: false })
-      .eq('user_id', userId);
+      .eq('user_id', userId)
+      .range(start,end)
       
-    const { data, error } = response;
     if (error) {
       console.error(error);
-      return NextResponse.json({ message: error.message }, { status: 500 });
     }
 
     return NextResponse.json(data);

--- a/src/components/common/PayButton.tsx
+++ b/src/components/common/PayButton.tsx
@@ -14,7 +14,7 @@ export type Products = {
   name: string | null;
   amount: number;
   quantity: number;
-  id: string | null;
+  id?: string;
 }[];
 
 interface Props {

--- a/src/components/common/PayButton.tsx
+++ b/src/components/common/PayButton.tsx
@@ -144,6 +144,7 @@ const PayButton = ({ orderNameArr, product, text }: Props) => {
           variant: 'destructive',
           description: '결제에 실패했습니다. 다시 시도해주세요.'
         });
+        setIsPaymentOpen(false);
         setLastCallTime(0);
         return router.replace(`${pathName}`);
       }

--- a/src/components/common/PayButton.tsx
+++ b/src/components/common/PayButton.tsx
@@ -138,7 +138,8 @@ const PayButton = ({ orderNameArr, product, text }: Props) => {
         }
       });
       const paymentId = response?.paymentId;
-
+      console.log(response);
+      //TODO 에러 코드에 따라 토스트 다르게 띄우기
       if (response?.code != null) {
         toast({
           variant: 'destructive',
@@ -148,7 +149,7 @@ const PayButton = ({ orderNameArr, product, text }: Props) => {
         setLastCallTime(0);
         return router.replace(`${pathName}`);
       }
-
+      setIsPaymentOpen(false);
       router.push(
         `/check-payment?paymentId=${paymentId}&totalQuantity=${totalQuantity}`
       );

--- a/src/hooks/payment/getProductImage.ts
+++ b/src/hooks/payment/getProductImage.ts
@@ -1,3 +1,23 @@
+// export const imageSrc = async (name: string) => {
+
+//   const {data, error} = await supabase
+//   .from('local_food')
+//   .select('title_image')
+//   .eq('food_name', name)
+//   .single()
+
+//   if(error){
+//     console.error(error)
+//   }
+//   if(!data?.title_image){
+//     return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/Tiger_Sad.png'
+//   }
+
+
+//   return data.title_image[0]
+// };
+
+//TODO PayHistoryList 의 orderList(product) 가공하는 훅으로 변경 or 제거
 export const imageSrc = (name: string) => {
   switch (name) {
     case '옥천 복숭아':

--- a/src/hooks/payment/getProductImage.ts
+++ b/src/hooks/payment/getProductImage.ts
@@ -1,23 +1,3 @@
-// export const imageSrc = async (name: string) => {
-
-//   const {data, error} = await supabase
-//   .from('local_food')
-//   .select('title_image')
-//   .eq('food_name', name)
-//   .single()
-
-//   if(error){
-//     console.error(error)
-//   }
-//   if(!data?.title_image){
-//     return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/Tiger_Sad.png'
-//   }
-
-
-//   return data.title_image[0]
-// };
-
-//TODO PayHistoryList 의 orderList(product) 가공하는 훅으로 변경 or 제거
 export const imageSrc = (name: string) => {
   switch (name) {
     case '옥천 복숭아':
@@ -34,6 +14,21 @@ export const imageSrc = (name: string) => {
 
     case '논산 딸기':
       return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/product3.jpg';
+
+    case '영덕 대게':
+      return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/product6.jepg'
+
+    case '안동 간고등어':
+      return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/product7.jepg';
+
+    case '이천 도자기 찻잔':
+      return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/product8.jepg';
+
+    case '해남 배추':
+      return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/product9.jpeg';
+
+    case '가평 잣':
+      return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/product10.jpeg';
 
     default:
       return 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/local-food/Tiger_Sad.png';

--- a/src/types/payHistory.ts
+++ b/src/types/payHistory.ts
@@ -1,7 +1,5 @@
 import { Tables } from "./supabase";
 
-type ExcludeFromNullable = 'payment_id';
-
 export interface Product {
   amount: number;
   id: string;
@@ -16,8 +14,8 @@ export interface Order extends Omit<Tables<'orderd_list'>, 'products'> {
   products: Product[] | null;
 }
 
-export type NullablePropertiesExcept<T> = {
-  [P in keyof T]: P 
+export type NullablePropertiesExcept<T, K extends keyof T = never> = {
+  [P in keyof T]: P extends K ? T[P] : T[P] | null
 };
 
 export interface BaseOrderInPayHistory {
@@ -32,13 +30,7 @@ export interface BaseOrderInPayHistory {
     pay_provider: string;
     user_name: string;
     phone_number: string;
-    products: 
-        {
-            id: string;
-            name: string;
-            amount: number;
-            quantity: number;
-        }[]
+    products: Product[]
     created_at: string;
     user_email: string;
 }
@@ -84,7 +76,6 @@ export interface PayHistory  {
   version: string;
   scheduleId?: string;
   billingKey?: string;
-  // 웹훅은 사용 안하니 지정 안함
   requestedAt: string;
   updatedAt: string;
   statusChangedAt: string;


### PR DESCRIPTION

[refactor]
- 주문 내역 리스트, 아이템 컴포넌트 분리
- 사용자 인터렉션이 발생하는 리뷰 작성 모달에 "use client" 명시
- layout.tsx 서버 컴포넌트로 변경(useDesktop 제거 후 css로 미디어 쿼리 구현)
: 초기 로드 속도 100ms 감소 및 seo 점수 오른 것 확인했습니다

[fix]
- 결제 실패시에 결제 버튼 비활성화가 풀리지 않는 것 발견해 수정

[etc]
- 이름 대조해 이미지 url 가져오는 switch문 새 상품 추가
(supabase 테이블에서 대조해서 가져오려했으나 로드 시간이 너무 지연되어서 일단 하드코딩 해뒀고, 더 나은 방법이 있을지 더 고민해보겠습니다)