### PR TITLE
쿠폰 적용 및 환불 시 쿠폰 생성

### DIFF
--- a/src/app/api/payment/webhook/route.ts
+++ b/src/app/api/payment/webhook/route.ts
@@ -2,13 +2,14 @@
 
 //해당 파일 위치가 webhook url 입니다
 
-//feat1) 환불 시, supabase 'orderd_list' 테이블의 status 항목 업데이트
+//feat1) 환불 시, 'orderd_list' 테이블 status 항목 업데이트
 // - 사업자 등록 안 된 가결제라 자정 전 일괄 환불됨
 // - 해당 환불 로직 추적 및 db 업데이트 위해 필요
 
-//TODO feat2) 환불 시, 쿠폰을 사용한 결제일 경우 사용한(삭제된) 쿠폰 살리기
+//feat2) 환불 시 users 테이블에 쿠폰 다시 추가
+// - 쿠폰이 현재는 하나인데, 추가 될 경우에는 구조 변경 필요
 
-//update: 24.8.8
+//update: 24.10.23
 
 import supabase from "@/utils/supabase/client";
 import { NextRequest } from "next/server";
@@ -22,20 +23,34 @@ type WebhookRes = {
     cancellationId: string;
   }
 }
+
+//회원가입 쿠폰
+const MEMBERSHIP_COUPON : string = 'https://kejbzqdwablccrontqrb.supabase.co/storage/v1/object/public/images/Coupon.png'
+
 export const POST = async (request: NextRequest) => {
   try {
     const response : WebhookRes = await request.json();
-
     const paymentId = response.data.paymentId
 
     if(response.type === 'Transaction.Cancelled'){
-      const {error} = await supabase
+      //주문 내역 status 결제 취소로 업데이트
+      const {data: newHistoryData, error : historyUpdateError} = await supabase
       .from('orderd_list')
       .update({status:'CANCELLED'})
       .eq('payment_id',paymentId)
+      .select()
+      .single()
 
-      if(error){
-        console.error('update error:',error)
+      if(historyUpdateError) console.error('error_failed update order history,', historyUpdateError);
+
+      //쿠폰 되살리기
+      if(newHistoryData){
+        const {error : addCouponError} = await supabase
+        .from('users')
+        .update({coupon: MEMBERSHIP_COUPON})
+        .eq('id', newHistoryData.user_id as string)
+
+        if(addCouponError) console.log('error_failed add again membership coupon,',addCouponError);
       }
     }
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -259,6 +259,7 @@ export type Database = {
           amount: number | null
           created_at: string | null
           id: string
+          is_CouponApplied: boolean | null
           order_name: string | null
           pay_provider: string | null
           payment_date: string | null
@@ -275,6 +276,7 @@ export type Database = {
           amount?: number | null
           created_at?: string | null
           id?: string
+          is_CouponApplied?: boolean | null
           order_name?: string | null
           pay_provider?: string | null
           payment_date?: string | null
@@ -291,6 +293,7 @@ export type Database = {
           amount?: number | null
           created_at?: string | null
           id?: string
+          is_CouponApplied?: boolean | null
           order_name?: string | null
           pay_provider?: string | null
           payment_date?: string | null
@@ -451,15 +454,7 @@ export type Database = {
           password?: string | null
           reportedUserId?: string[] | null
         }
-        Relationships: [
-          {
-            foreignKeyName: "users_id_fkey"
-            columns: ["id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
     }
     Views: {
@@ -574,4 +569,19 @@ export type Enums<
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
     ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never


### PR DESCRIPTION
- supabase 주문 내역 테이블에 is_CouponApplied colmn 추가(types/supabase 파일 변경 있음)
- 쿠폰 적용 여부 - 결제 확인 페이지 url에 쿼리스트링 전달
- 쿠폰 사용 시, is_CouponApplied true 사용 안할 시, false로 저장(더미값 props 전달 값으로 변경 예정)
- 쿠폰 사용 시 users 테이블 coupon - null로 변경
- 환불 시 users 테이블 coupon 다시 추가(웹훅)

쿠폰 되살리는 건 로컬 환경에선 ngrok 서버로 웹훅 url 추가 후 테스트해야합니다(정상 작동 확인했음)